### PR TITLE
Export from_str_header and csv_heade macros

### DIFF
--- a/crates/sip-types/src/header/mod.rs
+++ b/crates/sip-types/src/header/mod.rs
@@ -88,6 +88,7 @@ impl<H: HeaderParse> DecodeValues for H {
     }
 }
 
+#[macro_export]
 macro_rules! csv_header {
     ($(#[$meta:meta])* $struct_name:ident, $wrapping:ty, $header_name:expr) => {
         $(#[$meta])*
@@ -130,6 +131,7 @@ macro_rules! csv_header {
     };
 }
 
+#[macro_export]
 macro_rules! from_str_header {
     ($(#[$meta:meta])* $struct_name:ident, $header_name:expr, $from_str_ty:ty) => {
         $(#[$meta])*

--- a/crates/sip-types/src/header/mod.rs
+++ b/crates/sip-types/src/header/mod.rs
@@ -1,19 +1,18 @@
 //! Contains everything header related
 
-use anyhow::{Context, Result};
-use bytesstr::BytesStr;
-
-pub use error::HeaderError;
-use headers::OneOrMore;
-use name::Name;
-
 use crate::parse::{ParseCtx, Parser};
 use crate::print::PrintCtx;
+use anyhow::{Context, Result};
+use bytesstr::BytesStr;
+use headers::OneOrMore;
+use name::Name;
 
 mod error;
 pub mod headers;
 pub mod multiple;
 pub(crate) mod name;
+
+pub use error::HeaderError;
 
 // ==== PARSE TRAITS ====
 

--- a/crates/sip-types/src/header/mod.rs
+++ b/crates/sip-types/src/header/mod.rs
@@ -1,18 +1,19 @@
 //! Contains everything header related
 
-use crate::parse::{ParseCtx, Parser};
-use crate::print::PrintCtx;
 use anyhow::{Context, Result};
 use bytesstr::BytesStr;
+
+pub use error::HeaderError;
 use headers::OneOrMore;
 use name::Name;
+
+use crate::parse::{ParseCtx, Parser};
+use crate::print::PrintCtx;
 
 mod error;
 pub(crate) mod headers;
 pub mod multiple;
 pub(crate) mod name;
-
-pub use error::HeaderError;
 
 // ==== PARSE TRAITS ====
 
@@ -95,12 +96,12 @@ macro_rules! csv_header {
         #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $struct_name(pub $wrapping);
 
-        impl ConstNamed for $struct_name {
+        impl $crate::header::ConstNamed for $struct_name {
             const NAME: Name = $header_name;
         }
 
-        impl HeaderParse for $struct_name {
-            fn parse<'i>(ctx: ParseCtx, i: &'i str) -> Result<(&'i str, Self)> {
+        impl $crate::header::HeaderParse for $struct_name {
+            fn parse<'i>(ctx: $crate::parse::ParseCtx, i: &'i str) -> Result<(&'i str, Self)> {
                 if let Some(comma_idx) = i.find(',') {
                     Ok((
                         &i[comma_idx..],
@@ -112,11 +113,11 @@ macro_rules! csv_header {
             }
         }
 
-        impl ExtendValues for $struct_name {
-            fn extend_values(&self, _: PrintCtx<'_>, values: &mut OneOrMore) {
+        impl $crate::header::ExtendValues for $struct_name {
+            fn extend_values(&self, _: $crate::print::PrintCtx<'_>, values: &mut $crate::header::headers::OneOrMore) {
                 let value = match values {
-                    OneOrMore::One(value) => value,
-                    OneOrMore::More(values) => {
+                    $crate::header::headers::OneOrMore::One(value) => value,
+                    $crate::header::headers::OneOrMore::More(values) => {
                         values.last_mut().expect("empty OneOrMore::More variant")
                     }
                 };
@@ -124,8 +125,8 @@ macro_rules! csv_header {
                 *value = format!("{}, {}", value, self.0).into();
             }
 
-            fn create_values(&self, _: PrintCtx<'_>) -> OneOrMore {
-                OneOrMore::One(self.0.to_string().into())
+            fn create_values(&self, _: $crate::print::PrintCtx<'_>) -> $crate::header::headers::OneOrMore {
+                $crate::header::headers::OneOrMore::One(self.0.to_string().into())
             }
         }
     };
@@ -138,23 +139,23 @@ macro_rules! from_str_header {
         #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $struct_name(pub $from_str_ty);
 
-        impl ConstNamed for $struct_name {
+        impl $crate::header::ConstNamed for $struct_name {
             const NAME: Name =  $header_name;
         }
 
-        impl HeaderParse for $struct_name {
-            fn parse<'i>(_: ParseCtx, i: &'i str) -> Result<(&'i str, Self)> {
+        impl $crate::header::HeaderParse for $struct_name {
+            fn parse<'i>(_: $crate::parse::ParseCtx, i: &'i str) -> Result<(&'i str, Self)> {
                 Ok(("", Self(i.trim().parse()?)))
             }
         }
 
-        impl ExtendValues for $struct_name {
-            fn extend_values(&self, ctx: PrintCtx<'_>, values: &mut OneOrMore) {
+        impl $crate::header::ExtendValues for $struct_name {
+            fn extend_values(&self, ctx: $crate::print::PrintCtx<'_>, values: &mut $crate::header::headers::OneOrMore) {
                 *values = self.create_values(ctx)
             }
 
-            fn create_values(&self, _: PrintCtx<'_>) -> OneOrMore {
-                OneOrMore::One(self.0.to_string().into())
+            fn create_values(&self, _: $crate::print::PrintCtx<'_>) -> $crate::header::headers::OneOrMore {
+                $crate::header::headers::OneOrMore::One(self.0.to_string().into())
             }
         }
 

--- a/crates/sip-types/src/header/mod.rs
+++ b/crates/sip-types/src/header/mod.rs
@@ -101,7 +101,7 @@ macro_rules! csv_header {
         }
 
         impl $crate::header::HeaderParse for $struct_name {
-            fn parse<'i>(ctx: $crate::parse::ParseCtx, i: &'i str) -> Result<(&'i str, Self)> {
+            fn parse<'i>(ctx: $crate::parse::ParseCtx, i: &'i str) -> Result<(&'i str, Self), Error> {
                 if let Some(comma_idx) = i.find(',') {
                     Ok((
                         &i[comma_idx..],
@@ -144,7 +144,7 @@ macro_rules! from_str_header {
         }
 
         impl $crate::header::HeaderParse for $struct_name {
-            fn parse<'i>(_: $crate::parse::ParseCtx, i: &'i str) -> Result<(&'i str, Self)> {
+            fn parse<'i>(_: $crate::parse::ParseCtx, i: &'i str) -> Result<(&'i str, Self), Error> {
                 Ok(("", Self(i.trim().parse()?)))
             }
         }

--- a/crates/sip-types/src/header/mod.rs
+++ b/crates/sip-types/src/header/mod.rs
@@ -31,8 +31,8 @@ pub trait DecodeValues: Sized {
     ///
     /// Implementations should assume that `values` will always yield at least one value
     fn decode<'i, I>(parser: Parser, values: &mut I) -> Result<(&'i str, Self)>
-        where
-            I: Iterator<Item=&'i BytesStr>;
+    where
+        I: Iterator<Item = &'i BytesStr>;
 }
 
 /// Simplified parse trait which plays nicer with nom parsers. Should be implemented
@@ -75,8 +75,8 @@ pub trait ExtendValues {
 
 impl<H: HeaderParse> DecodeValues for H {
     fn decode<'i, I>(parser: Parser, values: &mut I) -> Result<(&'i str, Self)>
-        where
-            I: Iterator<Item=&'i BytesStr>,
+    where
+        I: Iterator<Item = &'i BytesStr>,
     {
         let value = values.next().context("no items in values")?;
 

--- a/crates/sip-types/src/header/mod.rs
+++ b/crates/sip-types/src/header/mod.rs
@@ -31,8 +31,8 @@ pub trait DecodeValues: Sized {
     ///
     /// Implementations should assume that `values` will always yield at least one value
     fn decode<'i, I>(parser: Parser, values: &mut I) -> Result<(&'i str, Self)>
-    where
-        I: Iterator<Item = &'i BytesStr>;
+        where
+            I: Iterator<Item=&'i BytesStr>;
 }
 
 /// Simplified parse trait which plays nicer with nom parsers. Should be implemented
@@ -75,8 +75,8 @@ pub trait ExtendValues {
 
 impl<H: HeaderParse> DecodeValues for H {
     fn decode<'i, I>(parser: Parser, values: &mut I) -> Result<(&'i str, Self)>
-    where
-        I: Iterator<Item = &'i BytesStr>,
+        where
+            I: Iterator<Item=&'i BytesStr>,
     {
         let value = values.next().context("no items in values")?;
 

--- a/crates/sip-types/src/header/mod.rs
+++ b/crates/sip-types/src/header/mod.rs
@@ -11,7 +11,7 @@ use crate::parse::{ParseCtx, Parser};
 use crate::print::PrintCtx;
 
 mod error;
-pub(crate) mod headers;
+pub mod headers;
 pub mod multiple;
 pub(crate) mod name;
 

--- a/crates/sip-types/src/header/name.rs
+++ b/crates/sip-types/src/header/name.rs
@@ -57,8 +57,8 @@ impl PartialEq<str> for Name {
 }
 
 impl<T> From<T> for Name
-    where
-        T: Into<BytesStr> + AsRef<[u8]>,
+where
+    T: Into<BytesStr> + AsRef<[u8]>,
 {
     fn from(name: T) -> Self {
         Name::from_bytes(name)

--- a/crates/sip-types/src/header/name.rs
+++ b/crates/sip-types/src/header/name.rs
@@ -57,8 +57,8 @@ impl PartialEq<str> for Name {
 }
 
 impl<T> From<T> for Name
-where
-    T: Into<BytesStr> + AsRef<[u8]>,
+    where
+        T: Into<BytesStr> + AsRef<[u8]>,
 {
     fn from(name: T) -> Self {
         Name::from_bytes(name)

--- a/crates/sip-types/src/header/typed/accept.rs
+++ b/crates/sip-types/src/header/typed/accept.rs
@@ -1,7 +1,6 @@
 use anyhow::{Error, Result};
-use bytesstr::BytesStr;
-
 use crate::header::name::Name;
+use bytesstr::BytesStr;
 
 csv_header! {
     /// `Accept` header, contains only one supported format.
@@ -13,9 +12,8 @@ csv_header! {
 
 #[cfg(test)]
 mod test {
-    use crate::Headers;
-
     use super::*;
+    use crate::Headers;
 
     const ACCEPT_SDP: Accept = Accept(BytesStr::from_static("application/sdp"));
     const ACCEPT_TEXT: Accept = Accept(BytesStr::from_static("text/plain"));

--- a/crates/sip-types/src/header/typed/accept.rs
+++ b/crates/sip-types/src/header/typed/accept.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
 use bytesstr::BytesStr;
 
 use crate::header::name::Name;

--- a/crates/sip-types/src/header/typed/accept.rs
+++ b/crates/sip-types/src/header/typed/accept.rs
@@ -1,10 +1,7 @@
-use crate::header::headers::OneOrMore;
-use crate::header::name::Name;
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
-use crate::parse::ParseCtx;
-use crate::print::PrintCtx;
 use anyhow::Result;
 use bytesstr::BytesStr;
+
+use crate::header::name::Name;
 
 csv_header! {
     /// `Accept` header, contains only one supported format.
@@ -16,8 +13,9 @@ csv_header! {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::Headers;
+
+    use super::*;
 
     const ACCEPT_SDP: Accept = Accept(BytesStr::from_static("application/sdp"));
     const ACCEPT_TEXT: Accept = Accept(BytesStr::from_static("text/plain"));

--- a/crates/sip-types/src/header/typed/accept.rs
+++ b/crates/sip-types/src/header/typed/accept.rs
@@ -1,5 +1,5 @@
-use anyhow::{Error, Result};
 use crate::header::name::Name;
+use anyhow::{Error, Result};
 use bytesstr::BytesStr;
 
 csv_header! {

--- a/crates/sip-types/src/header/typed/allow.rs
+++ b/crates/sip-types/src/header/typed/allow.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
 
 use crate::header::name::Name;
 use crate::method::Method;

--- a/crates/sip-types/src/header/typed/allow.rs
+++ b/crates/sip-types/src/header/typed/allow.rs
@@ -1,7 +1,6 @@
-use anyhow::{Error, Result};
-
 use crate::header::name::Name;
 use crate::method::Method;
+use anyhow::{Error, Result};
 
 csv_header! {
     /// `Allow` header, contains only one method.

--- a/crates/sip-types/src/header/typed/allow.rs
+++ b/crates/sip-types/src/header/typed/allow.rs
@@ -1,10 +1,7 @@
-use crate::header::headers::OneOrMore;
-use crate::header::name::Name;
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
-use crate::method::Method;
-use crate::parse::ParseCtx;
-use crate::print::PrintCtx;
 use anyhow::Result;
+
+use crate::header::name::Name;
+use crate::method::Method;
 
 csv_header! {
     /// `Allow` header, contains only one method.
@@ -16,8 +13,9 @@ csv_header! {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::Headers;
+
+    use super::*;
 
     const ALLOW_INVITE: Allow = Allow(Method::INVITE);
     const ALLOW_CANCEL: Allow = Allow(Method::CANCEL);

--- a/crates/sip-types/src/header/typed/allow.rs
+++ b/crates/sip-types/src/header/typed/allow.rs
@@ -13,9 +13,8 @@ csv_header! {
 
 #[cfg(test)]
 mod test {
-    use crate::Headers;
-
     use super::*;
+    use crate::Headers;
 
     const ALLOW_INVITE: Allow = Allow(Method::INVITE);
     const ALLOW_CANCEL: Allow = Allow(Method::CANCEL);

--- a/crates/sip-types/src/header/typed/content.rs
+++ b/crates/sip-types/src/header/typed/content.rs
@@ -40,9 +40,8 @@ impl ExtendValues for ContentType {
 
 #[cfg(test)]
 mod test {
-    use crate::Headers;
-
     use super::*;
+    use crate::Headers;
 
     #[test]
     fn print_content_length() {

--- a/crates/sip-types/src/header/typed/content.rs
+++ b/crates/sip-types/src/header/typed/content.rs
@@ -1,11 +1,10 @@
-use anyhow::{Error, Result};
-use bytesstr::BytesStr;
-
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
 use crate::header::headers::OneOrMore;
 use crate::header::name::Name;
+use crate::header::{ConstNamed, ExtendValues, HeaderParse};
 use crate::parse::ParseCtx;
 use crate::print::PrintCtx;
+use anyhow::{Error, Result};
+use bytesstr::BytesStr;
 
 from_str_header! {
     /// `Content-Length` header

--- a/crates/sip-types/src/header/typed/content.rs
+++ b/crates/sip-types/src/header/typed/content.rs
@@ -40,8 +40,9 @@ impl ExtendValues for ContentType {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::Headers;
+
+    use super::*;
 
     #[test]
     fn print_content_length() {

--- a/crates/sip-types/src/header/typed/content.rs
+++ b/crates/sip-types/src/header/typed/content.rs
@@ -1,10 +1,11 @@
+use anyhow::{Error, Result};
+use bytesstr::BytesStr;
+
+use crate::header::{ConstNamed, ExtendValues, HeaderParse};
 use crate::header::headers::OneOrMore;
 use crate::header::name::Name;
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
 use crate::parse::ParseCtx;
 use crate::print::PrintCtx;
-use anyhow::Result;
-use bytesstr::BytesStr;
 
 from_str_header! {
     /// `Content-Length` header

--- a/crates/sip-types/src/header/typed/expires.rs
+++ b/crates/sip-types/src/header/typed/expires.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
 
 use crate::Name;
 

--- a/crates/sip-types/src/header/typed/expires.rs
+++ b/crates/sip-types/src/header/typed/expires.rs
@@ -1,6 +1,5 @@
-use anyhow::{Error, Result};
-
 use crate::Name;
+use anyhow::{Error, Result};
 
 from_str_header! {
     /// `Expires` header
@@ -18,9 +17,8 @@ from_str_header! {
 
 #[cfg(test)]
 mod test {
-    use crate::Headers;
-
     use super::*;
+    use crate::Headers;
 
     const EXPIRES: Expires = Expires(300);
 

--- a/crates/sip-types/src/header/typed/expires.rs
+++ b/crates/sip-types/src/header/typed/expires.rs
@@ -1,9 +1,6 @@
-use crate::header::headers::OneOrMore;
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
-use crate::parse::ParseCtx;
-use crate::print::PrintCtx;
-use crate::Name;
 use anyhow::Result;
+
+use crate::Name;
 
 from_str_header! {
     /// `Expires` header
@@ -21,8 +18,9 @@ from_str_header! {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::Headers;
+
+    use super::*;
 
     const EXPIRES: Expires = Expires(300);
 

--- a/crates/sip-types/src/header/typed/extensions.rs
+++ b/crates/sip-types/src/header/typed/extensions.rs
@@ -1,10 +1,7 @@
-use crate::header::headers::OneOrMore;
-use crate::header::name::Name;
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
-use crate::parse::ParseCtx;
-use crate::print::PrintCtx;
 use anyhow::Result;
 use bytesstr::BytesStr;
+
+use crate::header::name::Name;
 
 csv_header! {
     /// `Supported` header, contains only one supported extension.

--- a/crates/sip-types/src/header/typed/extensions.rs
+++ b/crates/sip-types/src/header/typed/extensions.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
 use bytesstr::BytesStr;
 
 use crate::header::name::Name;

--- a/crates/sip-types/src/header/typed/extensions.rs
+++ b/crates/sip-types/src/header/typed/extensions.rs
@@ -1,7 +1,6 @@
+use crate::header::name::Name;
 use anyhow::{Error, Result};
 use bytesstr::BytesStr;
-
-use crate::header::name::Name;
 
 csv_header! {
     /// `Supported` header, contains only one supported extension.

--- a/crates/sip-types/src/header/typed/max_fwd.rs
+++ b/crates/sip-types/src/header/typed/max_fwd.rs
@@ -1,9 +1,6 @@
-use crate::header::headers::OneOrMore;
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
-use crate::parse::ParseCtx;
-use crate::print::PrintCtx;
-use crate::Name;
 use anyhow::Result;
+
+use crate::Name;
 
 from_str_header! {
     /// `Max-Forwards` header
@@ -14,9 +11,12 @@ from_str_header! {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::parse::ParseCtx;
     use bytesstr::BytesStr;
+
+    use crate::header::HeaderParse;
+    use crate::parse::ParseCtx;
+
+    use super::*;
 
     #[test]
     fn max_fwd() {

--- a/crates/sip-types/src/header/typed/max_fwd.rs
+++ b/crates/sip-types/src/header/typed/max_fwd.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
 
 use crate::Name;
 

--- a/crates/sip-types/src/header/typed/max_fwd.rs
+++ b/crates/sip-types/src/header/typed/max_fwd.rs
@@ -1,6 +1,5 @@
-use anyhow::{Error, Result};
-
 use crate::Name;
+use anyhow::{Error, Result};
 
 from_str_header! {
     /// `Max-Forwards` header
@@ -11,12 +10,10 @@ from_str_header! {
 
 #[cfg(test)]
 mod test {
-    use bytesstr::BytesStr;
-
-    use crate::header::HeaderParse;
-    use crate::parse::ParseCtx;
-
     use super::*;
+    use crate::parse::ParseCtx;
+    use crate::header::HeaderParse;
+    use bytesstr::BytesStr;
 
     #[test]
     fn max_fwd() {

--- a/crates/sip-types/src/header/typed/prack.rs
+++ b/crates/sip-types/src/header/typed/prack.rs
@@ -51,7 +51,7 @@ impl HeaderParse for RAck {
             )),
             |(rack, cseq, method)| RAck { rack, cseq, method },
         )(i)
-            .finish()?;
+        .finish()?;
 
         Ok((rem, rack))
     }
@@ -75,9 +75,8 @@ impl fmt::Display for RAck {
 
 #[cfg(test)]
 mod test {
-    use crate::Headers;
-
     use super::*;
+    use crate::Headers;
 
     const RACK: RAck = RAck {
         rack: 123,

--- a/crates/sip-types/src/header/typed/prack.rs
+++ b/crates/sip-types/src/header/typed/prack.rs
@@ -1,16 +1,19 @@
-use crate::header::headers::OneOrMore;
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
-use crate::method::Method;
-use crate::parse::ParseCtx;
-use crate::print::PrintCtx;
-use crate::Name;
-use anyhow::Result;
-use internal::ws;
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{Error, Result};
 use nom::character::complete::digit1;
 use nom::combinator::{map, map_res};
 use nom::Finish;
-use std::fmt;
-use std::str::FromStr;
+
+use internal::ws;
+
+use crate::header::{ConstNamed, ExtendValues, HeaderParse};
+use crate::header::headers::OneOrMore;
+use crate::method::Method;
+use crate::Name;
+use crate::parse::ParseCtx;
+use crate::print::PrintCtx;
 
 from_str_header! {
     /// `RSeq` header

--- a/crates/sip-types/src/header/typed/prack.rs
+++ b/crates/sip-types/src/header/typed/prack.rs
@@ -1,19 +1,16 @@
-use std::fmt;
-use std::str::FromStr;
-
+use crate::header::headers::OneOrMore;
+use crate::header::{ConstNamed, ExtendValues, HeaderParse};
+use crate::method::Method;
+use crate::parse::ParseCtx;
+use crate::print::PrintCtx;
+use crate::Name;
 use anyhow::{Error, Result};
+use internal::ws;
 use nom::character::complete::digit1;
 use nom::combinator::{map, map_res};
 use nom::Finish;
-
-use internal::ws;
-
-use crate::header::{ConstNamed, ExtendValues, HeaderParse};
-use crate::header::headers::OneOrMore;
-use crate::method::Method;
-use crate::Name;
-use crate::parse::ParseCtx;
-use crate::print::PrintCtx;
+use std::fmt;
+use std::str::FromStr;
 
 from_str_header! {
     /// `RSeq` header

--- a/crates/sip-types/src/header/typed/prack.rs
+++ b/crates/sip-types/src/header/typed/prack.rs
@@ -51,7 +51,7 @@ impl HeaderParse for RAck {
             )),
             |(rack, cseq, method)| RAck { rack, cseq, method },
         )(i)
-        .finish()?;
+            .finish()?;
 
         Ok((rem, rack))
     }
@@ -75,8 +75,9 @@ impl fmt::Display for RAck {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::Headers;
+
+    use super::*;
 
     const RACK: RAck = RAck {
         rack: 123,

--- a/crates/sip-types/src/header/typed/timer.rs
+++ b/crates/sip-types/src/header/typed/timer.rs
@@ -63,7 +63,7 @@ impl HeaderParse for SessionExpires {
                 }
             },
         )(i)
-        .finish()?;
+            .finish()?;
 
         Ok((rem, se))
     }
@@ -95,8 +95,9 @@ impl Print for SessionExpires {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use bytesstr::BytesStr;
+
+    use super::*;
 
     #[test]
     fn min_se() {

--- a/crates/sip-types/src/header/typed/timer.rs
+++ b/crates/sip-types/src/header/typed/timer.rs
@@ -1,15 +1,18 @@
-use crate::header::{ConstNamed, ExtendValues, HeaderParse, OneOrMore};
-use crate::parse::ParseCtx;
-use crate::print::{AppendCtx, Print, PrintCtx};
-use crate::uri::params::{Params, CPS};
-use crate::Name;
-use anyhow::Result;
-use internal::ws;
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{Error, Result};
 use nom::character::complete::alphanumeric1;
 use nom::combinator::{map, map_res};
 use nom::Finish;
-use std::fmt;
-use std::str::FromStr;
+
+use internal::ws;
+
+use crate::header::{ConstNamed, ExtendValues, HeaderParse, OneOrMore};
+use crate::Name;
+use crate::parse::ParseCtx;
+use crate::print::{AppendCtx, Print, PrintCtx};
+use crate::uri::params::{CPS, Params};
 
 from_str_header! {
     /// `Min-SE` header

--- a/crates/sip-types/src/header/typed/timer.rs
+++ b/crates/sip-types/src/header/typed/timer.rs
@@ -1,18 +1,15 @@
-use std::fmt;
-use std::str::FromStr;
-
+use crate::header::{ConstNamed, ExtendValues, HeaderParse, OneOrMore};
+use crate::parse::ParseCtx;
+use crate::print::{AppendCtx, Print, PrintCtx};
+use crate::uri::params::{Params, CPS};
+use crate::Name;
 use anyhow::{Error, Result};
+use internal::ws;
 use nom::character::complete::alphanumeric1;
 use nom::combinator::{map, map_res};
 use nom::Finish;
-
-use internal::ws;
-
-use crate::header::{ConstNamed, ExtendValues, HeaderParse, OneOrMore};
-use crate::Name;
-use crate::parse::ParseCtx;
-use crate::print::{AppendCtx, Print, PrintCtx};
-use crate::uri::params::{CPS, Params};
+use std::fmt;
+use std::str::FromStr;
 
 from_str_header! {
     /// `Min-SE` header

--- a/crates/sip-types/src/header/typed/timer.rs
+++ b/crates/sip-types/src/header/typed/timer.rs
@@ -63,7 +63,7 @@ impl HeaderParse for SessionExpires {
                 }
             },
         )(i)
-            .finish()?;
+        .finish()?;
 
         Ok((rem, se))
     }
@@ -95,9 +95,8 @@ impl Print for SessionExpires {
 
 #[cfg(test)]
 mod test {
-    use bytesstr::BytesStr;
-
     use super::*;
+    use bytesstr::BytesStr;
 
     #[test]
     fn min_se() {


### PR DESCRIPTION
Hi,

another small improvement would be to export the two macros `from_str_header` and `csv_header`.

Then someone can easily use them to create custom headers like this:

```rust
use ezk_sip_types::{csv_header, Name};
use bytesstr::BytesStr;

csv_header! {
    /// P-Access-Network-Info header
    PAccessNetworkInfo,
    BytesStr,
    Name::custom("P-Access-Network-Info", &["p-access-network-info"])
} 
```
What do you think about this?