### PR TITLE
Add more header field names

### DIFF
--- a/crates/sip-types/src/header/name.rs
+++ b/crates/sip-types/src/header/name.rs
@@ -250,6 +250,15 @@ header_names! {
     /// [[RFC3262, Section 20.34](https://datatracker.ietf.org/doc/html/rfc3262#section-7.1)]
     "RSeq",                 RSeq,               ["rseq"],                   RSEQ;
 
+    /// [[RFC3329, Section 2.6](https://datatracker.ietf.org/doc/html/rfc3329#section-2.6)]
+    "Security-Client",      SecurityClient,     ["security-client"],        SECURITY_CLIENT;
+
+    /// [[RFC3329, Section 2.6](https://datatracker.ietf.org/doc/html/rfc3329#section-2.6)]
+    "Security-Server",      SecurityServer,     ["security-server"],        SECURITY_SERVER;
+
+    /// [[RFC3329, Section 2.6](https://datatracker.ietf.org/doc/html/rfc3329#section-2.6)]
+    "Security-Verify",      SecurityVerify,     ["security-verify"],        SECURITY_VERIFY;
+
     /// [[RFC3621, Section 20.35](https://tools.ietf.org/html/rfc3261#section-20.35)]
     "Server",               Server,             ["server"],                 SERVER;
 

--- a/crates/sip-types/src/header/name.rs
+++ b/crates/sip-types/src/header/name.rs
@@ -196,6 +196,24 @@ header_names! {
     /// [[RFC3621, Section 20.25](https://tools.ietf.org/html/rfc3261#section-20.25)]
     "Organization",         Organization,       ["organization"],           ORGANIZATION;
 
+    /// [[RFC7315, Section 4.1](https://datatracker.ietf.org/doc/html/rfc7315#section-4.1)]
+    "P-Associated-URI",     PAssociatedURI,     ["p-associated-uri"],       P_ASSOCIATED_URI;
+
+    /// [[RFC7315, Section 4.2](https://datatracker.ietf.org/doc/html/rfc7315#section-4.2)]
+    "P-Called-Party-ID",   PCalledPartyID,     ["p-called-party-id"],      P_CALLED_PARTY_ID;
+
+    /// [[RFC7315, Section 4.3](https://datatracker.ietf.org/doc/html/rfc7315#section-4.3)]
+    "P-Visited-Network-ID", PVisitedNetworkID, ["p-visited-network-id"],   P_VISITED_NETWORK_ID;
+
+    /// [[RFC7315, Section 4.4](https://datatracker.ietf.org/doc/html/rfc7315#section-4.4)]
+    "P-Access-Network-Info", PAccessNetworkInfo, ["p-access-network-info"], P_ACCESS_NETWORK_INFO;
+
+    /// [[RFC7315, Section 4.5](https://datatracker.ietf.org/doc/html/rfc7315#section-4.5)]
+    "P-Charging-Function-Addresses", PChargingFunctionAddresses, ["p-charging-function-addresses"], P_CHARGING_FUNCTION_ADDRESSES;
+
+    /// [[RFC7315, Section 4.6](https://datatracker.ietf.org/doc/html/rfc7315#section-4.6)]
+    "P-Charging-Vector", PChargingVector, ["p-charging-vector"], P_CHARGING_VECTOR;
+
     /// [[RFC3621, Section 20.26](https://tools.ietf.org/html/rfc3261#section-20.26)]
     "Priority",             Priority,           ["priority"],               PRIORITY;
 


### PR DESCRIPTION
Hi,

I added more header names. Here is a link where a current list of SIP headers can be found:
https://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml#sip-parameters-2

This change should be easy to review. For a new release, I think it should only change the patch version of the sip-types crate.

Are you ok with that?