### PR TITLE
Add ?Sized to insert functions

### DIFF
--- a/crates/sip-types/src/header/headers.rs
+++ b/crates/sip-types/src/header/headers.rs
@@ -59,13 +59,13 @@ impl Headers {
 
     /// Inserts `header` using its [`HeaderNamed`] and [`InsertIntoHeaders`] implementation to the front of the list
     #[inline]
-    pub fn insert_named_front<H: DynNamed + ExtendValues>(&mut self, header: &H) {
+    pub fn insert_named_front<H: DynNamed + ExtendValues + ?Sized>(&mut self, header: &H) {
         self.insert_type_front(header.name(), header)
     }
 
     /// Inserts `header` using its [`InsertIntoHeaders`] implementation to the front of the list
     #[inline]
-    pub fn insert_type_front<H: ExtendValues>(&mut self, name: Name, header: &H) {
+    pub fn insert_type_front<H: ExtendValues + ?Sized>(&mut self, name: Name, header: &H) {
         let ctx = PrintCtx::default();
 
         if let Some(Entry { values, .. }) = self.entry_mut(&name) {
@@ -107,13 +107,13 @@ impl Headers {
 
     /// Inserts `header` using its [`DynNamed`] and [`ExtendValues`] implementation to the list
     #[inline]
-    pub fn insert_named<H: DynNamed + ExtendValues>(&mut self, header: &H) {
+    pub fn insert_named<H: DynNamed + ExtendValues + ?Sized>(&mut self, header: &H) {
         self.insert_type(header.name(), header)
     }
 
     /// Inserts `header` using its [`ExtendValues`] implementation to the list
     #[inline]
-    pub fn insert_type<H: ExtendValues>(&mut self, name: Name, header: &H) {
+    pub fn insert_type<H: ExtendValues + ?Sized>(&mut self, name: Name, header: &H) {
         let ctx = PrintCtx::default();
 
         if let Some(Entry { values, .. }) = self.entry_mut(&name) {


### PR DESCRIPTION
Hi,

I would like to use the crate like that:

```rust
use ezk_sip_core::Request;
use ezk_sip_types::header::typed::{CSeq, Expires};
use ezk_sip_types::header::ExtendValues;
use ezk_sip_types::uri::Uri;
use ezk_sip_types::{Method, Name};
use std::error::Error;
use std::str::FromStr;
use ezk_sip_types::uri::sip::SipUri;

pub struct Registration {
    /// The registrar of the registration (will be used in the request line)
    registrar: Box<dyn Uri>,
    /// Additional headers to be added to the request
    headers: Vec<(Name, Box<dyn ExtendValues>)>,
}

/// Implement Display trait for `Registration`
impl Registration {
    /// Create a new `Registration`
    pub fn new(
        registrar: Box<dyn Uri>,
    ) -> Self {
        // Add example headers
        let headers: Vec<(Name, Box<dyn ExtendValues>)> = vec![
            (Name::EXPIRES, Box::new(Expires(60u32))),
            (Name::CSEQ, Box::new(CSeq::new(1, Method::REGISTER))),
        ];

        Self {
            registrar,
            headers,
        }
    }

    /// Create a request from `Registration`
    pub fn create_request(&mut self) -> Result<Request, Box<dyn Error>> {
        let mut request = Request::new(Method::REGISTER, self.registrar.clone());

        // Set headers
        for (name, header) in &self.headers {
            request.headers.insert_type(name.clone(), header.as_ref());
        }
        Ok(request)
    }
}

fn main() {
    // Create SIP URI for registrar
    let registrar = SipUri::from_str("sip:localhost").unwrap();

    // Create register request
    let mut registration = Registration::new(
        Box::from(registrar)
    );
    let request = registration.create_request().unwrap();

    // Print request
    println!("{:?}", request);
}
```

To have the opportunity to also use trait objects like this `Box<dyn Header>` above, it would be nice to add `?Sized` to the insert functions.

What do you think about this change?