### PR TITLE
Change data type of Max-Forwards header from u32 to u8

### DIFF
--- a/crates/sip-types/src/header/typed/max_fwd.rs
+++ b/crates/sip-types/src/header/typed/max_fwd.rs
@@ -4,7 +4,7 @@ from_str_header! {
     /// `Max-Forwards` header
     MaxForwards,
     Name::MAX_FORWARDS,
-    u32
+    u8
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi,

in https://datatracker.ietf.org/doc/html/rfc3261#section-20.22 it says that only the values 0-255 are allowed, u32 would allow more than that.

So I suggest to change the data type to u8.