### PR TITLE
Update idna via updating hickory_resolver to fix RUSTSEC-2024-0421

### DIFF
--- a/crates/sip-core/Cargo.toml
+++ b/crates/sip-core/Cargo.toml
@@ -35,7 +35,7 @@ parking_lot = "0.12"
 rand = "0.8"
 bytesstr = "1"
 downcast-rs = "1"
-hickory-resolver = "0.24"
+hickory-resolver = "0.25.0-alpha.4"
 multimap = "0.10"
 nom = "7"
 

--- a/crates/sip-core/src/endpoint.rs
+++ b/crates/sip-core/src/endpoint.rs
@@ -573,7 +573,7 @@ impl EndpointBuilder {
     /// Set a `trust-dns-resolver` DNS resolver for the endpoint to use.
     ///
     /// Uses the system config by default.
-    pub fn set_dns_resolver(&mut self, dns_resolver: hickory_resolver::TokioAsyncResolver) {
+    pub fn set_dns_resolver(&mut self, dns_resolver: hickory_resolver::TokioResolver) {
         self.transports.set_dns_resolver(dns_resolver)
     }
 

--- a/crates/sip-core/src/transport/mod.rs
+++ b/crates/sip-core/src/transport/mod.rs
@@ -302,7 +302,7 @@ pub(crate) struct Transports {
 
     stun: StunEndpoint<StunUser>,
 
-    dns_resolver: hickory_resolver::TokioAsyncResolver,
+    dns_resolver: hickory_resolver::TokioResolver,
 }
 
 impl Transports {
@@ -561,7 +561,7 @@ impl Transports {
 pub(crate) struct TransportsBuilder {
     unmanaged: Vec<TpHandle>,
     factories: Vec<Arc<dyn Factory>>,
-    dns_resolver: Option<hickory_resolver::TokioAsyncResolver>,
+    dns_resolver: Option<hickory_resolver::TokioResolver>,
 }
 
 impl TransportsBuilder {
@@ -575,13 +575,13 @@ impl TransportsBuilder {
         self.factories.push(factory);
     }
 
-    pub(crate) fn set_dns_resolver(&mut self, dns_resolver: hickory_resolver::TokioAsyncResolver) {
+    pub(crate) fn set_dns_resolver(&mut self, dns_resolver: hickory_resolver::TokioResolver) {
         self.dns_resolver = Some(dns_resolver);
     }
 
     pub(crate) fn build(&mut self) -> Transports {
         let dns_resolver = self.dns_resolver.take().unwrap_or_else(|| {
-            hickory_resolver::TokioAsyncResolver::tokio_from_system_conf()
+            hickory_resolver::TokioResolver::tokio_from_system_conf()
                 .expect("Failed to create default system DNS resolver")
         });
 

--- a/crates/sip-core/src/transport/resolver.rs
+++ b/crates/sip-core/src/transport/resolver.rs
@@ -1,7 +1,7 @@
 use hickory_resolver::ResolveError;
 use hickory_resolver::proto::rr::rdata::{NAPTR, SRV};
 use hickory_resolver::proto::rr::{RData, RecordType};
-use hickory_resolver::{Name, TokioAsyncResolver};
+use hickory_resolver::{Name, TokioResolver};
 use multimap::MultiMap;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
@@ -68,7 +68,7 @@ impl Transport {
 
 #[tracing::instrument(err, skip(dns_resolver, uri_port))]
 pub(super) async fn resolve_host(
-    dns_resolver: &TokioAsyncResolver,
+    dns_resolver: &TokioResolver,
     name: &str,
     uri_port: u16,
 ) -> io::Result<Vec<ServerEntry>> {
@@ -113,7 +113,7 @@ pub(super) async fn resolve_host(
 }
 
 async fn resolve_naptr_records(
-    dns_resolver: &TokioAsyncResolver,
+    dns_resolver: &TokioResolver,
     name: Name,
     entries: &mut Vec<ServerEntry>,
 ) -> Result<(), ResolveError> {
@@ -192,7 +192,7 @@ async fn resolve_naptr_records(
 }
 
 async fn resolve_srv_records(
-    dns_resolver: &TokioAsyncResolver,
+    dns_resolver: &TokioResolver,
     name: Name,
     transport: Option<Transport>,
     entries: &mut Vec<ServerEntry>,
@@ -245,7 +245,7 @@ async fn resolve_srv_records(
 }
 
 async fn resolve_a_records(
-    dns_resolver: &TokioAsyncResolver,
+    dns_resolver: &TokioResolver,
     name: Name,
     transport: Option<Transport>,
     port: u16,

--- a/crates/sip-core/src/transport/resolver.rs
+++ b/crates/sip-core/src/transport/resolver.rs
@@ -1,4 +1,4 @@
-use hickory_resolver::error::{ResolveError, ResolveErrorKind};
+use hickory_resolver::ResolveError;
 use hickory_resolver::proto::rr::rdata::{NAPTR, SRV};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::{Name, TokioAsyncResolver};
@@ -130,7 +130,7 @@ async fn resolve_naptr_records(
     // Order records by 'order' field
     let mut naptr_records: Vec<&NAPTR> = lookup
         .record_iter()
-        .filter_map(|record| match record.data()? {
+        .filter_map(|record| match record.data() {
             RData::NAPTR(naptr) => Some(naptr),
             record_data => {
                 log::warn!("Got unexpected DNS record from NAPTR request, {record_data:?}");
@@ -208,7 +208,7 @@ async fn resolve_srv_records(
     // Order SRV records by priority
     let mut srv_records: Vec<&SRV> = lookup
         .record_iter()
-        .filter_map(|record| match record.data()? {
+        .filter_map(|record| match record.data() {
             RData::SRV(srv) => Some(srv),
             _ => None,
         })
@@ -220,7 +220,7 @@ async fn resolve_srv_records(
     // Often we also get some A/AAAA records for the highest priority, so map them
     let ip_records: MultiMap<&Name, IpAddr> = lookup
         .record_iter()
-        .filter_map(|record| match record.data()? {
+        .filter_map(|record| match record.data() {
             RData::A(a) => Some((record.name(), IpAddr::from(a.0))),
             RData::AAAA(aaaa) => Some((record.name(), IpAddr::from(aaaa.0))),
             _ => None,
@@ -275,7 +275,7 @@ async fn resolve_a_records(
 fn filter_no_records<T>(e: Result<T, ResolveError>) -> Result<Option<T>, ResolveError> {
     match e {
         Ok(t) => Ok(Some(t)),
-        Err(e) if matches!(e.kind(), ResolveErrorKind::NoRecordsFound { .. }) => Ok(None),
+        Err(e) if e.proto().map_or(false, |p| p.is_no_records_found()) => Ok(None),
         Err(e) => Err(e),
     }
 }


### PR DESCRIPTION
Hi,

with cargo-deny I got the message, that idna should be upgraded to a newer version because of https://rustsec.org/advisories/RUSTSEC-2024-0421.html.

For that we need to upgrade hickory-resolver to [v0.25.0-alpha.4](https://github.com/hickory-dns/hickory-dns/releases/tag/v0.25.0-alpha.4).

Bump commit: https://github.com/hickory-dns/hickory-dns/commit/f1ffcbf513bc2f87f602709b5577197b9f901a63.

So I upgraded it and fix the errors and deprecated imports.