### PR TITLE
fix: proceeding timeout too short

### DIFF
--- a/crates/sip-core/src/transaction/client_inv.rs
+++ b/crates/sip-core/src/transaction/client_inv.rs
@@ -147,6 +147,7 @@ impl ClientInvTsx {
     async fn handle_msg(&mut self, msg: TsxResponse) -> Result<Option<TsxResponse>> {
         match msg.line.code.kind() {
             CodeKind::Provisional => {
+                self.timeout = Instant::now() + T1 * 240; // 2 minutes
                 self.state = State::Proceeding;
             }
             CodeKind::Success => {


### PR DESCRIPTION
The default client invite timeout is currently 30 seconds for both the initiating and proceeding states. However, this duration is too short for some SIP providers.

To address this, we need to extend the timeout specifically for the proceeding state to prevent incorrect detection. Consider increasing it to 2 minutes.