### PR TITLE
fix(sip-ua): remove tag from REGISTER refresh

### DIFF
--- a/sip/sip-ua/src/register/mod.rs
+++ b/sip/sip-ua/src/register/mod.rs
@@ -82,10 +82,6 @@ impl Registration {
                 self.expires = expires;
             }
         }
-
-        if self.to.tag.is_none() {
-            self.to.tag = response.base_headers.to.tag;
-        }
     }
 
     /// Handle an error response received from a registrar


### PR DESCRIPTION
FreeSWITCH rejects the current REGISTER request message with `481 Call/Transaction Does Not Exist`.

From RFC 3261 §8.1.1.2:

>    A request outside of a dialog MUST NOT contain a To tag; the tag in
>    the To field of a request identifies the peer of the dialog.  Since
>    no dialog is established, no tag is present.

From RFC 3261 §10.2:

>    A REGISTER request does not establish a dialog.  A UAC MAY include a
>    Route header field in a REGISTER request based on a pre-existing
>    route set as described in Section 8.1.