### PR TITLE
fix(sip-types): do not quote qop value

### DIFF
--- a/media/ice/src/lib.rs
+++ b/media/ice/src/lib.rs
@@ -528,7 +528,7 @@ impl IceAgent {
         }
 
         self.pairs
-            .sort_unstable_by(|a, b| b.priority.cmp(&a.priority));
+            .sort_unstable_by_key(|b| std::cmp::Reverse(b.priority));
 
         self.prune_pairs();
     }
@@ -570,7 +570,7 @@ impl IceAgent {
                 CandidatePairNomination::None
             },
         });
-        pairs.sort_unstable_by(|a, b| b.priority.cmp(&a.priority));
+        pairs.sort_unstable_by_key(|b| std::cmp::Reverse(b.priority));
     }
 
     fn recompute_pair_priorities(&mut self) {
@@ -583,7 +583,7 @@ impl IceAgent {
         }
 
         self.pairs
-            .sort_unstable_by(|a, b| b.priority.cmp(&a.priority));
+            .sort_unstable_by_key(|b| std::cmp::Reverse(b.priority));
     }
 
     /// Prune the lowest priority pairs until `max_pairs` is reached

--- a/sip/sip-types/src/header/typed/auth.rs
+++ b/sip/sip-types/src/header/typed/auth.rs
@@ -422,7 +422,7 @@ impl Print for DigestResponse {
         if let Some(qop_response) = &self.qop_response {
             write!(
                 f,
-                r#", qop="{}", cnonce="{}", nc={:08X}"#,
+                r#", qop={}, cnonce="{}", nc={:08X}"#,
                 qop_response.qop, qop_response.cnonce, qop_response.nc
             )?;
         }
@@ -1238,7 +1238,7 @@ mod test {
             }],
         });
 
-        let expected = r#"Digest username="alice", realm="example.com", nonce="abc123", uri="sip:bob@example.com", response="00000000000000000000000000000000", algorithm=SHA-256, opaque="opaque_value", qop="auth", cnonce="def456", nc=00000001, another-field="some_extension""#;
+        let expected = r#"Digest username="alice", realm="example.com", nonce="abc123", uri="sip:bob@example.com", response="00000000000000000000000000000000", algorithm=SHA-256, opaque="opaque_value", qop=auth, cnonce="def456", nc=00000001, another-field="some_extension""#;
 
         assert_eq!(expected, digest.default_print_ctx().to_string());
     }


### PR DESCRIPTION
The `qop` value should follow RFC2617, as outlined in RFC3261 Section 20.6.
The `qop` value should not be quoted as outlined in RFC2617 Section 3.2.1.