### PR TITLE
fix(rtc): replace use of deprecated quin_udp method

### DIFF
--- a/media/rtc/src/tokio/socket.rs
+++ b/media/rtc/src/tokio/socket.rs
@@ -52,7 +52,7 @@ impl Socket {
                 let result = self.socket.try_io(Interest::WRITABLE, || {
                     let udp_ref = UdpSockRef::from(&self.socket);
 
-                    self.state.send(
+                    self.state.try_send(
                         udp_ref,
                         &Transmit {
                             destination: *destination,
@@ -64,10 +64,17 @@ impl Socket {
                     )
                 });
 
-                // Only return WouldBlock
-                if result.is_ok() {
-                    self.to_send.pop_front();
-                    continue 'outer;
+                match result {
+                    Ok(()) => {
+                        self.to_send.pop_front();
+                        continue 'outer;
+                    }
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(e) => {
+                        log::warn!("Failed to send UDP packet to {destination}: {e}");
+                        self.to_send.pop_front();
+                        continue 'outer;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolves

```
    Checking ezk-rtc v0.0.1 (/home/runner/work/ezk/ezk/media/rtc)
error: use of deprecated method `quinn_udp::UdpSocketState::send`: silences I/O errors; use `UdpSocketState::try_send() instead
Error:   --> media/rtc/src/tokio/socket.rs:55:32
   |
55 |                     self.state.send(
   |                                ^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(deprecated)]`

error: could not compile `ezk-rtc` (lib) due to 1 previous error
```